### PR TITLE
FIX: refresh discovery categories on logo click

### DIFF
--- a/app/assets/javascripts/discourse/controllers/discovery/categories.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery/categories.js.es6
@@ -46,5 +46,10 @@ export default DiscoveryController.extend({
         ? "categories_only"
         : style;
     return Ember.String.dasherize(componentName);
+  },
+  actions: {
+    refresh() {
+      this.send('triggerRefresh');
+    }
   }
 });

--- a/app/assets/javascripts/discourse/controllers/discovery/categories.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery/categories.js.es6
@@ -49,7 +49,7 @@ export default DiscoveryController.extend({
   },
   actions: {
     refresh() {
-      this.send('triggerRefresh');
+      this.send("triggerRefresh");
     }
   }
 });

--- a/app/assets/javascripts/discourse/mixins/url-refresh.js.es6
+++ b/app/assets/javascripts/discourse/mixins/url-refresh.js.es6
@@ -13,6 +13,6 @@ export default {
   willDestroyElement() {
     this._super(...arguments);
 
-    this.appEvents.off("url:refresh", this, this.refresh);
+    this.appEvents.off("url:refresh");
   }
 };

--- a/app/assets/javascripts/discourse/routes/discovery-categories.js.es6
+++ b/app/assets/javascripts/discourse/routes/discovery-categories.js.es6
@@ -94,24 +94,8 @@ const DiscoveryCategoriesRoute = Discourse.Route.extend(OpenComposer, {
   },
 
   actions: {
-    refresh() {
-      const controller = this.controllerFor("discovery/categories");
-      const discController = this.controllerFor("discovery");
-
-      // Don't refresh if we're still loading
-      if (!discController || discController.get("loading")) {
-        return;
-      }
-
-      // If we `send('loading')` here, due to returning true it bubbles up to the
-      // router and ember throws an error due to missing `handlerInfos`.
-      // Lesson learned: Don't call `loading` yourself.
-      discController.set("loading", true);
-
-      this.model().then(model => {
-        this.setupController(controller, model);
-        controller.send("loadingComplete");
-      });
+    triggerRefresh() {
+      this.refresh();
     },
 
     createCategory() {

--- a/app/assets/javascripts/discourse/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/templates/discovery/categories.hbs
@@ -1,4 +1,4 @@
-{{#discovery-categories refresh=refresh}}
+{{#discovery-categories refresh=(action "refresh")}}
   {{component categoryPageStyle
               categories=model.categories
               latestTopicOnly=latestTopicOnly

--- a/app/assets/javascripts/discourse/templates/mobile/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/discovery/categories.hbs
@@ -1,4 +1,4 @@
-{{#discovery-categories refresh=refresh}}
+{{#discovery-categories refresh=(action "refresh")}}
   {{component categoryPageStyle
               categories=model.categories
               latestTopicOnly=latestTopicOnly


### PR DESCRIPTION
This is a refactor of https://github.com/discourse/discourse/commit/037776881b1ab157fd26e5d3d656bd5ef32e9ce9 

The initial fix broke tests: `route-action-helper` couldn't resolve the action (the ember-route-action-helper repo also warns about [this not working in tests](https://github.com/DockYard/ember-route-action-helper)). 

I also noticed that the `url:refresh` callback wasn't being unregistered correctly. Case in point: when switching from "/categories" to "/latest" and back to "/categories", the `refresh` action for "/latest" was still being triggered when clicking on the site logo. 

The proposed solution in this PR does the following:

* registers an action in the categories controller that triggers a refresh on its route
* uses Ember's [refresh](https://emberjs.com/api/ember/3.7/classes/Route/methods/refresh?anchor=refresh) method on the route
* consistently unregisters the refresh app event